### PR TITLE
Prevent auto-complete on form control

### DIFF
--- a/src/letterbox.jsx
+++ b/src/letterbox.jsx
@@ -38,6 +38,7 @@ const LetterBox = ({ id, letter, state, isFocused, onChange, onSubmit }) => {
         size="lg"
         type="text"
         placeholder=""
+        autoComplete="off"
         value={letter}
         onChange={(event) => handleChange(event.target.value)}
         onKeyPress={(event) => handleKeyPress(event)}


### PR DESCRIPTION
Don't show the auto-complete drop-down when entering letters.